### PR TITLE
Dockerizing RePlAce

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.gitignore
+.gitmodules
+Dockerfile
+README.md
+doc
+prerequisite

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM centos:7
+LABEL maintainer="Abdelrahman Hosny <abdelrahman@brown.edu>" 
+
+# install gcc 7
+RUN yum -y install centos-release-scl && \
+    yum -y install devtoolset-7 devtoolset-7-libatomic-devel
+ENV CC=/opt/rh/devtoolset-7/root/usr/bin/gcc \
+    CPP=/opt/rh/devtoolset-7/root/usr/bin/cpp \
+    CXX=/opt/rh/devtoolset-7/root/usr/bin/g++ \
+    PATH=/opt/rh/devtoolset-7/root/usr/bin:$PATH
+
+# install dependencies 
+RUN yum update -y && \
+    yum install -y wget libstdc++-devel libstdc++-static libX11-devel \
+    boost-devel zlib-devel tcl-devel autoconf automake swig flex libtool \
+    libtool-ltdl gmp-devel mpfr-devel libmpc-devel bison byacc ctags \ 
+    ImageMagick ImageMagick-devel
+
+# install Intel MKL and IPP
+RUN yum-config-manager --add-repo https://yum.repos.intel.com/setup/intelproducts.repo && \
+    rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB && \
+    yum install -y intel-mkl-2018.2-046 intel-ipp-2018.4-057
+
+# add source code
+COPY . RePlAce 
+
+# install RePlAce 
+RUN cd RePlAce && \
+    make clean && \
+    make && \
+    make install
+
+# test installation
+RUN yum install -y  && \
+    cd RePlAce/test && \
+    ./run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,5 @@ RUN cd RePlAce && \
     make install
 
 # test installation
-RUN yum install -y  && \
-    cd RePlAce/test && \
+RUN cd RePlAce/test && \
     ./run.sh

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 |:--:| 
 | *Visualized examples from ISPD 2006 contest; adaptec2.inf* |
 
-# Getting Started
+## Getting Started
 
 ## Run using Docker
 * Install Docker on [Windows](https://docs.docker.com/docker-for-windows/), [Mac](https://docs.docker.com/docker-for-mac/) or [Linux](https://docs.docker.com/install/).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,22 @@
 |:--:| 
 | *Visualized examples from ISPD 2006 contest; adaptec2.inf* |
 
+# Getting Started
+
+## Run using Docker
+* Install Docker on [Windows](https://docs.docker.com/docker-for-windows/), [Mac](https://docs.docker.com/docker-for-mac/) or [Linux](https://docs.docker.com/install/).
+* Navigate to the directory where you have the input files.
+* Run RePlAce container:
+````
+docker run -it -v $(pwd):/data openroad/replace bash
+````
+
+4. From the interactive bash terminal, use RePlAce scripts which reside under `/RePlAce`. You can read input files from `/data` directory inside the docker container - which mirrors the host machine directory you are in. 
+
+The Docker image is self-contained and includes everything that RePlAce needs to work properly.
+
+## Install on a bare-metal machine
+
 ### Pre-requisite
 * Intel MKL and IPP package [Link](https://software.intel.com/en-us/articles/free-ipsxe-tools-and-libraries) >= 2016.3.210
 * GCC compiler and libstdc++ static library >= 5.4.0


### PR DESCRIPTION
This pull request proposes packaging RePlAcein a Docker image. Users don't have to run through lengthy and buggy installation steps. The Docker image is available on Docker Hub (`openroad/replace`).

After installing Docker, run OpenSTA using `docker run -it -v $(pwd):/input openroad/replace bash` where `-v $(pwd):/input` mounts the current directory to a directory inside the Docker container called input, where the input files reside.

The changes in the README file documents for users how to get started.

Link to Docker Hub: https://hub.docker.com/r/openroad/replace